### PR TITLE
v3.8.11

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,9 +18,10 @@ if [[ ${target_platform} =~ osx.* ]]; then
     export LC_ALL=en_US.UTF-8
 fi
 
-# libtoolize deletes things we need from build-aux, automake puts them back
-libtoolize --copy --force --verbose
-automake --add-missing --copy --verbose
+# Regenerate autotools files to match build environment versions
+# Skip gtkdocize since we disable gtk-doc in configure
+export GTKDOCIZE=true
+autoreconf -i --force --verbose
 
 declare -a configure_opts
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,7 +60,7 @@ about:
   home: https://www.gnutls.org/index.html
   license: LGPL-2.1-or-later
   license_family: LGPL
-  license_file: COPYING
+  license_file: COPYING.LESSERv2
   summary: GnuTLS is a secure communications library implementing the SSL, TLS and DTLS protocols
   description: |
     GnuTLS is a secure communications library implementing the SSL, TLS and DTLS protocols

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,9 +39,11 @@ requirements:
     - libidn2 {{ libidn2 }}
     - libtasn1 {{ libtasn1 }}
     - libunistring {{ libunistring }}
+    - zlib {{ zlib }}          # [linux]
     - ca-certificates 2025.12.2
   run:
     - gettext >=0.19.8.1     # [osx]
+    - libzlib >=1.3          # [linux]
     - ca-certificates
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - nettle {{ nettle }}
     # Optional dependencies but keep them
     - libidn2 {{ libidn2 }}
-    - libtasn1 {{ libtasn1}}
+    - libtasn1 {{ libtasn1 }}
     - libunistring {{ libunistring }}
     - ca-certificates 2025.12.2
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gnutls" %}
-{% set version = "3.8.7" %}
+{% set version = "3.8.11" %}
 
 {% set major_minor = ".".join(version.split(".")[:2]) %}
 
@@ -9,15 +9,13 @@ package:
 
 source:
   url: https://www.gnupg.org/ftp/gcrypt/{{ name }}/v{{ major_minor }}/{{ name }}-{{ version }}.tar.xz
-  sha256: fe302f2b6ad5a564bcb3678eb61616413ed5277aaf8e7bf7cdb9a95a18d9f477
+  sha256: 91bd23c4a86ebc6152e81303d20cf6ceaeb97bc8f84266d0faec6e29f17baa20
   patches:
     # https://gitlab.com/gnutls/gnutls/issues/660
     - 0003-Fix-libcrypto-test-it-must-always-fail.patch
-    # See https://gitlab.com/gnutls/gnutls/-/commit/f3e8eac0586a19f4dafd89f68006a536b826e65a?merge_request_iid=1866
-    - revert-back-to-datefudge-for-openssl-ocsp.patch
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win]
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=gnutls
@@ -33,15 +31,15 @@ requirements:
     - make
     - pkg-config
   host:
-    - gettext 0.21.0     # [osx]
+    - gettext {{ gettext }}    # [osx]
     - gmp {{ gmp }}
     # nettle 3.7.3 isn't available on s390x and win-64
     - nettle {{ nettle }}
     # Optional dependencies but keep them
     - libidn2 {{ libidn2 }}
-    - libtasn1 4.19
-    - libunistring 1.3
-    - ca-certificates 2024.12.31
+    - libtasn1 {{ libtasn1}}
+    - libunistring {{ libunistring }}
+    - ca-certificates 2025.12.2
   run:
     - gettext >=0.19.8.1     # [osx]
     - ca-certificates
@@ -60,7 +58,7 @@ about:
   home: https://www.gnutls.org/index.html
   license: LGPL-2.1-or-later
   license_family: LGPL
-  license_file: LICENSE
+  license_file: COPYING
   summary: GnuTLS is a secure communications library implementing the SSL, TLS and DTLS protocols
   description: |
     GnuTLS is a secure communications library implementing the SSL, TLS and DTLS protocols


### PR DESCRIPTION
gnutls v3.8.11

[PKG-11006](https://anaconda.atlassian.net/browse/PKG-11006)
[upstream](https://gitlab.com/gnutls/gnutls/-/tree/3.8.11?ref_type=tags)

## Changes
- Bump version and SHA
- Use CBC pinnings
- Add zlib that's needed on linux
- Update license file to match upstream
- Call autoreconf to regenerate autotools files that were generated with a version of  autotools we don't have. 

[PKG-11006]: https://anaconda.atlassian.net/browse/PKG-11006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ